### PR TITLE
fix ensure models str input

### DIFF
--- a/bacpipe/core/workflows.py
+++ b/bacpipe/core/workflows.py
@@ -118,8 +118,8 @@ def ensure_models_exist(model_base_path, model_names, repo_id="vskode/bacpipe_mo
     ----------
     model_base_path : Path
         Local base directory where the checkpoints should be stored.
-    model_names : list
-        list of models to run
+    model_names : str or list
+        Model name or list of model names to run
     repo_id : str, optional
         Hugging Face Hub repo ID, by default "vinikay/bacpipe_models"
 
@@ -128,6 +128,11 @@ def ensure_models_exist(model_base_path, model_names, repo_id="vskode/bacpipe_mo
     str
         path to saved models
     """
+    if isinstance(model_names, str):
+        model_names = [model_names]
+    else:
+        model_names = list(model_names)
+
     model_base_path = Path(model_base_path)
     model_base_path.parent.mkdir(exist_ok=True, parents=True)
     


### PR DESCRIPTION
This PR allows `ensure_models_exist` to accept both a single model name as a string and a list of model names. Also makes it consistent with `generate_embeddings`, which accepts a single model name as a string.
